### PR TITLE
"file_info" provider should not return a trailing whitespace

### DIFF
--- a/lua/feline/presets/default.lua
+++ b/lua/feline/presets/default.lua
@@ -33,7 +33,10 @@ M.active[1] = {
             'slant_left_2',
             {str = ' ', hl = {bg = 'oceanblue', fg = 'NONE'}}
         },
-        right_sep = {'slant_right_2', ' '}
+        right_sep = {
+            {str = ' ', hl = {bg = 'oceanblue', fg = 'NONE'}},
+            'slant_right_2', ' '
+        }
     },
     {
         provider = 'file_size',

--- a/lua/feline/presets/noicon.lua
+++ b/lua/feline/presets/noicon.lua
@@ -31,7 +31,17 @@ M.active[1] = {
             bg = 'oceanblue',
             style = 'bold'
         },
-        right_sep = ' ',
+        left_sep = '',
+        right_sep = {
+            {
+                str = ' ',
+                hl = {
+                    fg = 'NONE',
+                    bg = 'oceanblue'
+                },
+            },
+            ' '
+        },
         icon = ''
     },
     {

--- a/lua/feline/providers/file.lua
+++ b/lua/feline/providers/file.lua
@@ -119,12 +119,12 @@ function M.file_info(component, opts)
     if bo.modified then
         modified_str = opts.file_modified_icon or '●'
 
-        if modified_str ~= '' then modified_str = modified_str .. ' ' end
+        if modified_str ~= '' then modified_str = ' ' .. modified_str end
     else
         modified_str = ''
     end
 
-    return string.format(' %s%s %s', readonly_str, filename, modified_str), icon
+    return string.format(' %s%s%s', readonly_str, filename, modified_str), icon
 end
 
 function M.file_size()


### PR DESCRIPTION
Hello, 

TLDR: Every buildin provider except the `file_info` provider returns a string without trailing whitespace. In order to be consistent, the `file_info` provider should adapt to this behaviour. The missing whitespace can easily be added by the user by using separators.

Long version: Consider the following example

```lua
table.insert(components.active[1], {
    provider = 'file_info'
})
table.insert(components.active[1], {
    provider = 'git_branch',
    -- Only show the git branch, when the current file is inside the git repo
    enabled = function ()
        local path = vim.fn.expand('%:p')
        local cwd = vim.fn.getcwd()
        if path:find(cwd) ~= nil then return true end
    end,
})
table.insert(components.active[1], {
    provider = 'file_size',
    left_sep = ' ',
})
```

When the `git_branch` section is enabled, all three sections are separated by a whitespace, because the `file_info` provider adds a trailing whitespace, the `git_branch` provider adds no whitespaces and the `file_size` sections defines a leading whitespace (the `left_sep`). However, when the `git_branch` section is not shown (because the `enabled` function evaluates to false) the two remaining sections are divided by two whitespaces (instead of one).

The best solution would be that the `file_info` provider adds no trailing whitespace and the user takes care for the separtors in the configuration.