### PR TITLE
refactor: use vim.diagnostic for lsp provider

### DIFF
--- a/lua/feline/providers/lsp.lua
+++ b/lua/feline/providers/lsp.lua
@@ -8,7 +8,12 @@ function M.is_lsp_attached()
 end
 
 function M.get_diagnostics_count(severity)
-  return vim.tbl_count(diagnostic.get(0, { severity = severity }))
+    if vim.fn.has "nvim-0.6" then
+        return vim.tbl_count(diagnostic.get(0, { severity = severity }))
+    else
+        -- TODO: drop this when 0.5 is no longer used
+        return vim.lsp.diagnostic.get_count(0, ({ "Information", "Hint", "Warning", "Error" })[severity])
+    end
 end
 
 function M.diagnostics_exist(severity)

--- a/lua/feline/providers/lsp.lua
+++ b/lua/feline/providers/lsp.lua
@@ -1,23 +1,14 @@
 local M = {}
 
 local lsp = vim.lsp
+local diagnostic = vim.diagnostic
 
 function M.is_lsp_attached()
     return next(lsp.buf_get_clients(0)) ~= nil
 end
 
 function M.get_diagnostics_count(severity)
-    local active_clients = lsp.buf_get_clients(0)
-
-    if not active_clients then return 0 end
-
-    local count = 0
-
-    for _, client in pairs(active_clients) do
-        count = count + lsp.diagnostic.get_count(0, severity, client.id)
-    end
-
-    return count
+  return vim.tbl_count(diagnostic.get(0, { severity = severity }))
 end
 
 function M.diagnostics_exist(severity)
@@ -42,19 +33,19 @@ local function diagnostics(severity)
 end
 
 function M.diagnostic_errors()
-    return diagnostics('Error'), '  '
+    return diagnostics(diagnostic.severity.ERROR), '  '
 end
 
 function M.diagnostic_warnings()
-    return diagnostics('Warning'), '  '
+    return diagnostics(diagnostic.severity.WARN), '  '
 end
 
 function M.diagnostic_hints()
-    return diagnostics('Hint'), '  '
+    return diagnostics(diagnostic.severity.HINT), '  '
 end
 
 function M.diagnostic_info()
-    return diagnostics('Information'), '  '
+    return diagnostics(diagnostic.severity.INFO), '  '
 end
 
 return M


### PR DESCRIPTION
Currently `diagnostic_warnings` and `diagnostic_info` don't work on 0.6 due to the severity name.

Since most of the functions now are `diagnostic` related, I wonder if changing the filename from `lsp.lua` will be more suitable.

Requires neovim 0.6, so probably hold off on merging or we could patch the two functions that don't work on neovim 0.6.