### PR TITLE
fix: only check buffer local gitsigns info

### DIFF
--- a/lua/feline/providers/git.lua
+++ b/lua/feline/providers/git.lua
@@ -1,5 +1,4 @@
 local b = vim.b
-local g = vim.g
 
 local M = {}
 

--- a/lua/feline/providers/git.lua
+++ b/lua/feline/providers/git.lua
@@ -4,7 +4,7 @@ local g = vim.g
 local M = {}
 
 function M.git_branch()
-    return b.gitsigns_head or g.gitsigns_head or '', ' '
+    return b.gitsigns_head or '', ' '
 end
 
 -- Common function used by the git providers
@@ -32,7 +32,7 @@ end
 
 -- Utility function to check if git provider information is available
 function M.git_info_exists()
-    return g.gitsigns_head or b.gitsigns_head or b.gitsigns_status_dict
+    return b.gitsigns_head or b.gitsigns_status_dict
 end
 
 return M


### PR DESCRIPTION
When autochdir is disabled and user switches to a non-git file, the branch icon remains.

Closes #194 