### PR TITLE
fix: show "[No Name]" instead of "unnamed" for unnamed buffers

### DIFF
--- a/lua/feline/providers/file.lua
+++ b/lua/feline/providers/file.lua
@@ -99,7 +99,7 @@ function M.file_info(component, opts)
     end
 
     if filename == '' then
-        filename = 'unnamed'
+        filename = '[No Name]'
     end
 
     if bo.readonly then


### PR DESCRIPTION
To have more consistency with Neovim's built-in statusline configuration.