### PR TITLE
feat: add utility functions to check component truncation

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -164,6 +164,18 @@ end
 
 If you omit the provider value, it will be set to an empty string. A component with no provider or an empty provider may be useful for things like [applying a highlight to section gaps](#highlight-section-gaps) or just having an icon or separator as a component.
 
+#### Component name
+
+A component can optionally be given a name. While the component is not required to have a name and the name is mostly useless, it can be used to check if the component has been [truncated](#truncation). To give a component a name, just set its `name` value to a `string`, shown below:
+
+```
+local my_component = {
+    name = 'a_unique_name'
+}
+```
+
+Two components inside the `active` or `inactive` table cannot share the same name, so make sure to give all components unique names.
+
 #### Truncation
 
 Feline has an automatic smart truncation system where components can be automatically truncated if the statusline doesn't fit within the window. It can be useful if you want to make better use of screen space. It also allows you to better manage which providers are truncated, how they are truncated and in which order they are truncated.
@@ -227,6 +239,10 @@ local high_priority_component = {
 ```
 
 Priority can also be set to a negative number, which can be used to make a component be truncated earlier than the ones with default priority.
+
+##### Check if component is truncated or hidden
+
+If you give a component a `name`, you can check if that component has been truncated or hidden by Feline's smart truncation system through the utility functions, `require('feline').is_component_truncated` and `require('feline').is_component_hidden`. Both of these functions take two arguments, `winid` which is the window id of the window for which the component's truncation is being checked, the second is the `name` of the component. `is_component_truncated` returns `true` if a component has been truncated or hidden, and `is_component_hidden` returns `true` only if a component has been hidden.
 
 #### Conditionally enable components
 

--- a/lua/feline/generator.lua
+++ b/lua/feline/generator.lua
@@ -6,6 +6,10 @@ local feline = require('feline')
 local M = {
     -- Cached highlights
     highlights = {},
+    -- Used to check if a certain component is truncated
+    component_truncated = {},
+    -- Used to check if a certain component is hidden
+    component_hidden = {}
 }
 
 -- Return true if any pattern in tbl matches provided value
@@ -320,6 +324,7 @@ end
 -- Wrapper around parse_component that handles any errors that happen while parsing the components
 -- and points to the location of the component in case of any errors
 local function parse_component_handle_errors(
+    winid,
     component,
     use_short_provider,
     statusline_type,
@@ -331,10 +336,12 @@ local function parse_component_handle_errors(
     if not ok then
         api.nvim_err_writeln(
             string.format(
-                "Feline: error while processing component number %d on section %d of type '%s': %s",
+                "Feline: error while processing component number %d on section %d of type '%s' " ..
+                "for window %d: %s",
                 component_number,
                 component_section,
                 statusline_type,
+                winid,
                 result
             )
         )
@@ -358,6 +365,11 @@ end
 
 -- Generate statusline by parsing all components and return a string
 function M.generate_statusline(is_active)
+    local winid = api.nvim_get_current_win()
+
+    M.component_truncated[winid] = {}
+    M.component_hidden[winid] = {}
+
     if not feline.components or is_disabled() then
         return ''
     end
@@ -388,7 +400,30 @@ function M.generate_statusline(is_active)
         component_widths[i] = {}
 
         for j, component in ipairs(section) do
-            local component_str = parse_component_handle_errors(component, false, statusline_type, i, j)
+            if component.name then
+                if M.component_truncated[winid][component.name] ~= nil then
+                    api.nvim_err_writeln(
+                        string.format(
+                            "Feline: error while parsing components for window %d: " ..
+                            "Multiple components with name '%s'",
+                            winid,
+                            component.name
+                        )
+                    )
+                    return ''
+                end
+                M.component_truncated[winid][component.name] = false
+                M.component_hidden[winid][component.name] = false
+            end
+
+            local component_str = parse_component_handle_errors(
+                winid,
+                component,
+                false,
+                statusline_type,
+                i,
+                j
+            )
 
             local component_width = get_component_width(component_str)
 
@@ -421,7 +456,14 @@ function M.generate_statusline(is_active)
             local component = sections[section][number]
 
             if component.short_provider then
-                local component_str = parse_component_handle_errors(component, true, statusline_type, section, number)
+                local component_str = parse_component_handle_errors(
+                    winid,
+                    component,
+                    true,
+                    statusline_type,
+                    section,
+                    number
+                )
 
                 local component_width = get_component_width(component_str)
 
@@ -435,6 +477,10 @@ function M.generate_statusline(is_active)
                     statusline_width = statusline_width - width_difference
                     component_strs[section][number] = component_str
                     component_widths[section][number] = component_width
+
+                    if component.name then
+                        M.component_truncated[winid][component.name] = true
+                    end
                 end
             end
 
@@ -449,11 +495,17 @@ function M.generate_statusline(is_active)
     if statusline_width > window_width then
         for _, indices in ipairs(component_indices) do
             local section, number = indices[1], indices[2]
+            local component = sections[section][number]
 
-            if sections[section][number].truncate_hide then
+            if component.truncate_hide then
                 statusline_width = statusline_width - component_widths[section][number]
                 component_strs[section][number] = ''
                 component_widths[section][number] = 0
+
+                if component.name then
+                    M.component_truncated[winid][component.name] = true
+                    M.component_hidden[winid][component.name] = true
+                end
             end
 
             if statusline_width <= window_width then

--- a/lua/feline/generator.lua
+++ b/lua/feline/generator.lua
@@ -403,8 +403,8 @@ function M.generate_statusline(is_active)
                 if M.component_truncated[winid][component.name] ~= nil then
                     api.nvim_err_writeln(
                         string.format(
-                            "Feline: error while parsing components for window %d: " ..
-                                "Multiple components with name '%s'",
+                            "Feline: error while parsing components for window %d: "
+                                .. "Multiple components with name '%s'",
                             winid,
                             component.name
                         )
@@ -415,15 +415,7 @@ function M.generate_statusline(is_active)
                 M.component_hidden[winid][component.name] = false
             end
 
-            local component_str = parse_component_handle_errors(
-                winid,
-                component,
-                false,
-                statusline_type,
-                i,
-                j
-            )
-
+            local component_str = parse_component_handle_errors( winid, component, false, statusline_type, i, j)
             local component_width = get_component_width(component_str)
 
             component_strs[i][j] = component_str

--- a/lua/feline/generator.lua
+++ b/lua/feline/generator.lua
@@ -403,7 +403,7 @@ function M.generate_statusline(is_active)
                 if M.component_truncated[winid][component.name] ~= nil then
                     api.nvim_err_writeln(
                         string.format(
-                            "Feline: error while parsing components for window %d: "
+                            'Feline: error while parsing components for window %d: '
                                 .. "Multiple components with name '%s'",
                             winid,
                             component.name
@@ -415,7 +415,7 @@ function M.generate_statusline(is_active)
                 M.component_hidden[winid][component.name] = false
             end
 
-            local component_str = parse_component_handle_errors( winid, component, false, statusline_type, i, j)
+            local component_str = parse_component_handle_errors(winid, component, false, statusline_type, i, j)
             local component_width = get_component_width(component_str)
 
             component_strs[i][j] = component_str

--- a/lua/feline/generator.lua
+++ b/lua/feline/generator.lua
@@ -9,7 +9,7 @@ local M = {
     -- Used to check if a certain component is truncated
     component_truncated = {},
     -- Used to check if a certain component is hidden
-    component_hidden = {}
+    component_hidden = {},
 }
 
 -- Return true if any pattern in tbl matches provided value
@@ -336,8 +336,7 @@ local function parse_component_handle_errors(
     if not ok then
         api.nvim_err_writeln(
             string.format(
-                "Feline: error while processing component number %d on section %d of type '%s' " ..
-                "for window %d: %s",
+                "Feline: error while processing component number %d on section %d of type '%s' for window %d: %s",
                 component_number,
                 component_section,
                 statusline_type,
@@ -405,7 +404,7 @@ function M.generate_statusline(is_active)
                     api.nvim_err_writeln(
                         string.format(
                             "Feline: error while parsing components for window %d: " ..
-                            "Multiple components with name '%s'",
+                                "Multiple components with name '%s'",
                             winid,
                             component.name
                         )

--- a/lua/feline/init.lua
+++ b/lua/feline/init.lua
@@ -136,6 +136,26 @@ function M.use_theme(name_or_tbl)
     M.reset_highlights()
 end
 
+-- Check if component with `name` in the statusline of window `winid` is truncated or hidden
+function M.is_component_truncated(winid, name)
+    if gen.component_truncated[winid][name] == nil then
+        api.nvim_err_writeln(string.format("Component with name '%s' not found", name))
+        return
+    end
+
+    return gen.component_truncated[winid][name]
+end
+
+-- Check if component with `name` in the statusline of window `winid` is hidden
+function M.is_component_hidden(winid, name)
+    if gen.component_hidden[winid][name] == nil then
+        api.nvim_err_writeln(string.format("Component with name '%s' not found", name))
+        return
+    end
+
+    return gen.component_hidden[winid][name]
+end
+
 -- Setup Feline using the provided configuration options
 function M.setup(config)
     -- Check if Neovim version is 0.5 or greater


### PR DESCRIPTION
Ref: #170

Adds two utility functions, `require('feline').is_component_truncated` and `require('feline').is_component_hidden` to check if a component has been truncated or hidden.