### PR TITLE
fix: allow reloading feline configuration

### DIFF
--- a/lua/feline/init.lua
+++ b/lua/feline/init.lua
@@ -180,6 +180,9 @@ function M.setup(config)
     M.force_inactive = config.force_inactive
     M.disable = config.disable
 
+    -- Unload providers in case they were loaded before to prevent custom providers from old
+    -- configuration being cached
+    package.loaded['feline.providers'] = nil
     M.providers = require('feline.providers')
 
     -- Register custom providers


### PR DESCRIPTION
Previously, Feline configuration couldn't be reloaded due to the custom providers from the previous configuration being cached, causing an error if a provider with the same name was in the new configuration as well. This commit fixes that by unloading the feline providers Lua module before loading it, to prevent its values from being cached.

Closes #229