### PR TITLE
feat: allow updating providers through triggers

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -164,6 +164,32 @@ end
 
 If you omit the provider value, it will be set to an empty string. A component with no provider or an empty provider may be useful for things like [applying a highlight to section gaps](#highlight-section-gaps) or just having an icon or separator as a component.
 
+##### Update provider value using triggers
+
+Sometimes the provider value has to do some heavy operations, which makes it undesirable to run the provider function every time the statusline is generated. Feline allows you to conditionally re-run the provider function by triggering an update to the provider string through either an autocmd or a function. Until the provider function is run again, the value from the previous execution of the provider function is used as the provider string.
+
+Updating provider value through triggers is achieved through the `update` key in the `provider` table. `update` can be either a boolean value, a table or a function that returns a boolean value or a table. If it's a boolean value, then the provider will be updated if value is `true`. For example:
+
+```lua
+provider = {
+    name = 'my_provider',
+    -- Only update provider if there are less than 4 windows in the current tabpage
+    update = function()
+        return #vim.api.nvim_tabpage_list_wins(0) < 4
+    end
+}
+```
+
+If it's a table, it must contain a list of autocmds that will trigger an update for the provider. For example:
+
+```lua
+provider = {
+    name = 'my_provider',
+    -- Only update provider if a window is closed or if a buffer is deleted
+    update = { 'WinClosed', 'BufDelete' }
+}
+```
+
 #### Component name
 
 A component can optionally be given a name. While the component is not required to have a name and the name is mostly useless, it can be used to check if the component has been [truncated](#truncation). To give a component a name, just set its `name` value to a `string`, shown below:

--- a/lua/feline/generator.lua
+++ b/lua/feline/generator.lua
@@ -314,7 +314,7 @@ local function parse_provider(provider, component, is_short, winid, section_nr, 
 
                 provider_cache_tbl[winid][section_nr][component_nr] = {
                     str = cache_str,
-                    icon = cache_icon
+                    icon = cache_icon,
                 }
             end
 
@@ -343,11 +343,10 @@ local function parse_provider(provider, component, is_short, winid, section_nr, 
                                 winid,
                                 section_nr,
                                 component_nr
-                            )
-                        }
+                            ),
+                        },
                     }, 'feline', true)
                 end
-
             end
 
             str = provider_cache_tbl[winid][section_nr][component_nr].str

--- a/lua/feline/init.lua
+++ b/lua/feline/init.lua
@@ -217,6 +217,9 @@ function M.setup(config)
     -- Ensures custom quickfix statusline isn't loaded
     g.qf_disable_statusline = true
 
+    -- Clear statusline generator state
+    gen.clear_state()
+
     -- Set the value of the statusline option to Feline's statusline generation function
     opt.statusline = "%{%v:lua.require'feline'.statusline()%}"
 

--- a/lua/feline/utils.lua
+++ b/lua/feline/utils.lua
@@ -4,9 +4,12 @@ local cmd = vim.api.nvim_command
 local M = {}
 
 -- Utility function to create augroups
-function M.create_augroup(autocmds, name)
+function M.create_augroup(autocmds, name, no_clear)
     cmd('augroup ' .. name)
-    cmd('autocmd!')
+
+    if no_clear == nil or no_clear == false then
+        cmd('autocmd!')
+    end
 
     for _, autocmd in ipairs(autocmds) do
         cmd('autocmd ' .. table.concat(autocmd, ' '))


### PR DESCRIPTION
Providers can now be updated by autocmd and function triggers in order to prevent re-running a function everytime the statusline is generated.

Closes #227