### PR TITLE
fix(providers/file_info): don't transform the empty filename

### DIFF
--- a/lua/feline/providers/file.lua
+++ b/lua/feline/providers/file.lua
@@ -82,7 +82,9 @@ function M.file_info(component, opts)
         end
     end
 
-    if type == 'short-path' then
+    if filename == '' then
+        filename = '[No Name]'
+    elseif type == 'short-path' then
         filename = fn.pathshorten(filename)
     elseif type == 'base-only' then
         filename = fn.fnamemodify(filename, ':t')
@@ -96,10 +98,6 @@ function M.file_info(component, opts)
         filename = get_unique_filename(filename, true)
     elseif type ~= 'full-path' then
         filename = fn.fnamemodify(filename, ':t')
-    end
-
-    if filename == '' then
-        filename = '[No Name]'
     end
 
     if bo.readonly then


### PR DESCRIPTION
When opening an empty buffer and using the file_info provider with
opts.type = 'relative', the filename ends up becoming CWD. The solution
is to check that the filename is not empty, set it to '[No Name]' and
then skip all transformations.