### PR TITLE
fix: escape special statusline chars in filename component

### DIFF
--- a/lua/feline/providers/file.lua
+++ b/lua/feline/providers/file.lua
@@ -120,6 +120,8 @@ function M.file_info(component, opts)
         modified_str = ''
     end
 
+    -- escape any special statusline characters in the filename
+    filename = filename:gsub('%%', '%%%%')
     return string.format('%s%s%s', readonly_str, filename, modified_str), icon
 end
 


### PR DESCRIPTION
`jdt.ls` generates filenames with `%` in them e.g. 
```
jdt://contents/java.base/java.lang/StringBuilder.class?=jacoco/%5C/usr%5C/lib%5C/jvm%5C/java-17-openjdk-17.0.3.0.7-1.fc36.x86_64%5C/lib%5C/jrt-fs.jar%60java.base=/maven.pomderived=/true=/=/ja
vadoc_location=/https:%5C/%5C/docs.oracle.com%5C/en%5C/java%5C/javase%5C/17%5C/docs%5C/api%5C/=/%3Cjava.lang(StringBuilder.class
```
The `file_info` component reverse searches for the first occurrence of `/`, which in this case will contain `%3Cjava.lang(StringBuilder.class`. Unfortunately, `%` is a special character in the statusline (as you probably know), which causes feline to crash (in my case it's the winbar that's crashing).

Something to consider: you might want extract this escaping logic into a user-facing utils function. For instance, I also display the alt file in my winbar, which would also benefit from the same sanitazation.