### PR TITLE
feat: added "slashes" option to file_info provider

### DIFF
--- a/doc/feline.txt
+++ b/doc/feline.txt
@@ -970,8 +970,8 @@ through the provider `opts`:
     modified.<br> Default:`'●'`
 - `file_readonly_icon` (string): The icon that is shown when a file is
     read-only.<br> Default:`'🔒'`
-- slashes (string): If defined, replaces the slashes in a path with the given
-  string.<br> Default: null
+- `slashes` (string): If defined, replaces the slashes in a path with the given
+  string.<br> Default: `null`
 - `type` (string): Determines which parts of the filename are shown. Its value
     can be one of:
     - `'full-path'`: Full path of the file (eg: `'/home/user/.config/nvim/init.lua'`)

--- a/doc/feline.txt
+++ b/doc/feline.txt
@@ -970,6 +970,8 @@ through the provider `opts`:
     modified.<br> Default:`'●'`
 - `file_readonly_icon` (string): The icon that is shown when a file is
     read-only.<br> Default:`'🔒'`
+- slashes (string): If defined, replaces the slashes in a path with the given
+  string.<br> Default: null
 - `type` (string): Determines which parts of the filename are shown. Its value
     can be one of:
     - `'full-path'`: Full path of the file (eg: `'/home/user/.config/nvim/init.lua'`)

--- a/lua/feline/providers/file.lua
+++ b/lua/feline/providers/file.lua
@@ -99,6 +99,11 @@ function M.file_info(component, opts)
         filename = fn.fnamemodify(filename, ':t')
     end
 
+    -- Replace slashes if value is provided in options
+    if opts.slashes then
+        filename = filename:gsub("/",opts.slashes)
+    end
+
     if bo.readonly then
         readonly_str = opts.file_readonly_icon or '🔒'
     else


### PR DESCRIPTION
Added the ability for users to define a substitute for the slashes in a path. 

For example, 

`foo/bar/test.lua`

could turn into

`foo > bar > test.lua`

usage of this feature would look like this with these changes.

```lua
{
  provider = {
    name = "file_info",
    opts = { slashes = " > "},
  }
}
```