### PR TITLE
feat: add path_sep option to file_info provider

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -708,7 +708,7 @@ The `file_info` provider has some special provider options that can be passed th
 - `file_readonly_icon` (string): The icon that is shown when a file is read-only.<br>
   Default:`'🔒'`
 - `path_sep` (string): The separator character in the file path. <br>
-  Default: `/` or `\\` depending on OS 
+  Default: `/` or `\` depending on OS 
 - `type` (string): Determines which parts of the filename are shown. Its value can be one of:
 
   - `'full-path'`: Full path of the file (eg: `'/home/user/.config/nvim/init.lua'`)

--- a/USAGE.md
+++ b/USAGE.md
@@ -707,6 +707,8 @@ The `file_info` provider has some special provider options that can be passed th
   Default:`'●'`
 - `file_readonly_icon` (string): The icon that is shown when a file is read-only.<br>
   Default:`'🔒'`
+- `path_sep` (string): The separator character in the file path. <br>
+  Default: `/` or `\\` depending on OS 
 - `type` (string): Determines which parts of the filename are shown. Its value can be one of:
 
   - `'full-path'`: Full path of the file (eg: `'/home/user/.config/nvim/init.lua'`)

--- a/lua/feline/providers/file.lua
+++ b/lua/feline/providers/file.lua
@@ -66,9 +66,9 @@ local function get_path_separator()
     if jit then
         local os = string.lower(jit.os)
         if os == 'linux' or os == 'osx' or os == 'bsd' then
-            return '/'
+            return [[/]]
         else
-            return '\\'
+            return [[\]]
         end
     else
         return package.config:sub(1, 1)

--- a/lua/feline/providers/file.lua
+++ b/lua/feline/providers/file.lua
@@ -75,6 +75,8 @@ local function get_path_separator()
     end
 end
 
+local default_seperator = get_path_separator()
+
 function M.file_info(component, opts)
     local readonly_str, modified_str, icon
 
@@ -138,7 +140,6 @@ function M.file_info(component, opts)
     filename = filename:gsub('%%', '%%%%')
 
     if opts.path_sep then
-        local default_seperator = get_path_separator()
         filename = filename:gsub(default_seperator, opts.path_sep)
     end
 

--- a/lua/feline/providers/file.lua
+++ b/lua/feline/providers/file.lua
@@ -61,6 +61,20 @@ local function get_unique_filename(filename, shorten)
     return string.reverse(string.sub(filename, 1, index))
 end
 
+-- Get path separator depending on OS
+local function get_path_separator()
+  if jit then
+    local os = string.lower(jit.os)
+    if os == "linux" or os == "osx" or os == "bsd" then
+      return "/"
+    else
+      return "\\"
+    end
+  else
+    return package.config:sub(1, 1)
+  end
+end
+
 function M.file_info(component, opts)
     local readonly_str, modified_str, icon
 
@@ -122,6 +136,12 @@ function M.file_info(component, opts)
 
     -- escape any special statusline characters in the filename
     filename = filename:gsub('%%', '%%%%')
+
+    if opts.path_sep then
+      local default_seperator = get_path_separator()
+      filename = filename:gsub(default_seperator, opts.path_sep)
+    end
+
     return string.format('%s%s%s', readonly_str, filename, modified_str), icon
 end
 

--- a/lua/feline/providers/file.lua
+++ b/lua/feline/providers/file.lua
@@ -63,16 +63,16 @@ end
 
 -- Get path separator depending on OS
 local function get_path_separator()
-  if jit then
-    local os = string.lower(jit.os)
-    if os == "linux" or os == "osx" or os == "bsd" then
-      return "/"
+    if jit then
+        local os = string.lower(jit.os)
+        if os == 'linux' or os == 'osx' or os == 'bsd' then
+            return '/'
+        else
+            return '\\'
+        end
     else
-      return "\\"
+        return package.config:sub(1, 1)
     end
-  else
-    return package.config:sub(1, 1)
-  end
 end
 
 function M.file_info(component, opts)
@@ -138,8 +138,8 @@ function M.file_info(component, opts)
     filename = filename:gsub('%%', '%%%%')
 
     if opts.path_sep then
-      local default_seperator = get_path_separator()
-      filename = filename:gsub(default_seperator, opts.path_sep)
+        local default_seperator = get_path_separator()
+        filename = filename:gsub(default_seperator, opts.path_sep)
     end
 
     return string.format('%s%s%s', readonly_str, filename, modified_str), icon


### PR DESCRIPTION
`get_path_separator` function is originally from the plenary path module.
https://github.com/nvim-lua/plenary.nvim/blob/4b66054e75356ac0b909bbfee9c682e703f535c2/lua/plenary/path.lua#L21

Closes #301 