### PR TITLE
ci: bump stylua-action to version to v1

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -7,8 +7,8 @@ jobs:
     format:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
-            - uses: JohnnyMorganz/stylua-action@1.0.0
+            - uses: actions/checkout@v3
+            - uses: JohnnyMorganz/stylua-action@v1
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
                   args: --check .
@@ -17,6 +17,6 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Block Fixup Commit Merge
               uses: 13rac1/block-fixup-merge-action@v2.0.0


### PR DESCRIPTION
This way any non-breaking fixes to stylua-action will automatically be
used as v1 points to the latest version.

Also upgrade checkout to version 3.
