### PR TITLE
fix: remove unwanted print function call

### DIFF
--- a/lua/feline/generator.lua
+++ b/lua/feline/generator.lua
@@ -293,9 +293,6 @@ local function parse_provider(gen, provider, component, is_short, winid, section
         return str, icon
     end
 
-    if type(provider) == 'table' and provider.update then
-        print(vim.inspect(gen.provider_cache))
-    end
     -- If provider is a function, just evaluate it normally
     if type(provider) == 'function' then
         str, icon = provider(component)

--- a/lua/feline/generator.lua
+++ b/lua/feline/generator.lua
@@ -296,7 +296,6 @@ local function parse_provider(gen, provider, component, is_short, winid, section
     -- If provider is a function, just evaluate it normally
     if type(provider) == 'function' then
         str, icon = provider(component)
-
     -- If provider is a table, get the provider name and opts and evaluate the provider
     elseif type(provider) == 'table' then
         local provider_fn, provider_opts

--- a/lua/feline/generator.lua
+++ b/lua/feline/generator.lua
@@ -296,7 +296,8 @@ local function parse_provider(gen, provider, component, is_short, winid, section
     -- If provider is a function, just evaluate it normally
     if type(provider) == 'function' then
         str, icon = provider(component)
-        -- If provider is a table, get the provider name and opts and evaluate the provider
+
+    -- If provider is a table, get the provider name and opts and evaluate the provider
     elseif type(provider) == 'table' then
         local provider_fn, provider_opts
 


### PR DESCRIPTION
## Issue
When provider is a table with update key, the provider cache table gets printed.

## Replication
```lua
provider = {
  name = "file_type",
  update = {
    "FileType",
  },
}
```

## Solution
Remove the print function call along with the if statement.
https://github.com/feline-nvim/feline.nvim/blob/5d6a054c476f2c2e3de72022d8f59764e53946ee/lua/feline/generator.lua#L296-L298