### PR TITLE
feat: Added `macro` provider

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -623,6 +623,7 @@ Feline by default has some built-in providers to make your life easy. They are:
 | `line_percentage`                     | Current line percentage                        |
 | [`scroll_bar`](#scroll-bar)           | Scroll bar that shows file progress            |
 | [`search_count`](#search-count)       | Search count for current search                |
+| `macro`                               | Shows macro being recorded                     |
 | [`file_info`](#file-info)             | Get file icon, name and modified status        |
 | `file_size`                           | Get file size                                  |
 | `file_type`                           | Get file type                                  |

--- a/lua/feline/providers/cursor.lua
+++ b/lua/feline/providers/cursor.lua
@@ -82,4 +82,13 @@ function M.search_count()
     return string.format('[%d/%d]', result.current, math.min(result.total, result.maxcount))
 end
 
+function M.macro()
+    local recording_register = vim.fn.reg_recording()
+    if recording_register == '' then
+        return ''
+    else
+        return 'Recording @' .. recording_register
+    end
+end
+
 return M

--- a/lua/feline/providers/init.lua
+++ b/lua/feline/providers/init.lua
@@ -18,6 +18,7 @@ local get_provider_category = {
     line_percentage = 'cursor',
     scroll_bar = 'cursor',
     search_count = 'cursor',
+    macro = 'cursor',
 
     file_info = 'file',
     file_size = 'file',


### PR DESCRIPTION
Apparently checking for nil will keep the indicator active, just like the hlsearch one