### PR TITLE
Remove unnecessary spacing before line percentage

### DIFF
--- a/lua/feline/providers/cursor.lua
+++ b/lua/feline/providers/cursor.lua
@@ -58,7 +58,7 @@ function M.line_percentage()
     elseif curr_line == lines then
         return 'Bot'
     else
-        return string.format('%2d%%%%', math.ceil(curr_line / lines * 99))
+        return string.format('%d%%%%', math.ceil(curr_line / lines * 99))
     end
 end
 


### PR DESCRIPTION
By specifying `%2d` in the `string.format`, when the line percentage is a single digit value, there is a unwanted space at the beginning of the string, with this PR, the functionality should continue to work exactly as intended whilst avoiding that extra padding before the string.